### PR TITLE
Automated code changes to reduce warnings and streamline code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ charset = utf-8
 end_of_line = crlf
 indent_style = space
 indent_size = 4
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true
 
 
@@ -139,7 +139,8 @@ csharp_prefer_braces = true:warning
 dotnet_sort_system_directives_first = true
 # C# formatting settings
 # https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#c-formatting-settings
-csharp_new_line_before_open_brace = all
+# NOTE: list no longer includes: accessors, anonymous_methods, anonymous_types, events, indexers, local_functions
+csharp_new_line_before_open_brace = lambdas, types, object_collection, control_blocks, properties, methods
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
@@ -166,7 +167,7 @@ csharp_space_between_method_call_name_and_opening_parenthesis = false
 csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping options
 # https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#wrapping
-csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 # More Indentation options (Undocumented)
 csharp_indent_block_contents = true
@@ -366,4 +367,3 @@ dotnet_naming_rule.interface_types_must_be_prefixed_with_i.style    = prefix_int
 dotnet_naming_rule.parameters_must_be_camel_case.symbols  = parameters
 dotnet_naming_rule.parameters_must_be_camel_case.severity = warning
 dotnet_naming_rule.parameters_must_be_camel_case.style    = camel_case
-

--- a/.editorconfig
+++ b/.editorconfig
@@ -103,7 +103,7 @@ csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = false:suggestion # type confusion and signed/unsigned confusion risks
 # Expression-bodied members
 # https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#expression_bodied_members
-csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_methods = false:suggestion
 csharp_style_expression_bodied_constructors = when_on_single_line:suggestion
 csharp_style_expression_bodied_operators = when_on_single_line:suggestion
 csharp_style_expression_bodied_properties = when_on_single_line:suggestion

--- a/src/AssemblyDetail.cs
+++ b/src/AssemblyDetail.cs
@@ -36,35 +36,17 @@ namespace Zyrenth.Zora
 		/// <summary>
 		/// Gets the assembly company
 		/// </summary>
-		public string Company
-		{
-			get
-			{
-				return GetAttribute<AssemblyCompanyAttribute>(x => x.Company);
-			}
-		}
+		public string Company => GetAttribute<AssemblyCompanyAttribute>(x => x.Company);
 
 		/// <summary>
 		/// Gets the assembly copyright information
 		/// </summary>
-		public string Copyright
-		{
-			get
-			{
-				return GetAttribute<AssemblyCopyrightAttribute>(x => x.Copyright);
-			}
-		}
+		public string Copyright => GetAttribute<AssemblyCopyrightAttribute>(x => x.Copyright);
 
 		/// <summary>
 		/// Gets the description about the assembly.
 		/// </summary>
-		public string Description
-		{
-			get
-			{
-				return GetAttribute<AssemblyDescriptionAttribute>(x => x.Description);
-			}
-		}
+		public string Description => GetAttribute<AssemblyDescriptionAttribute>(x => x.Description);
 
 		/// <summary>
 		/// Gets the assembly's file version
@@ -88,46 +70,22 @@ namespace Zyrenth.Zora
 		/// <summary>
 		///  Gets the assembly's full name.
 		/// </summary>
-		public string Product
-		{
-			get
-			{
-				return GetAttribute<AssemblyProductAttribute>(x => x.Product);
-			}
-		}
+		public string Product => GetAttribute<AssemblyProductAttribute>(x => x.Product);
 
 		/// <summary>
 		/// Gets the assembly's version.
 		/// </summary>
-		public string ProductVersion
-		{
-			get
-			{
-				return GetAttribute<AssemblyInformationalVersionAttribute>(x => x.InformationalVersion) ?? FileVersion;
-			}
-		}
+		public string ProductVersion => GetAttribute<AssemblyInformationalVersionAttribute>(x => x.InformationalVersion) ?? FileVersion;
 
 		/// <summary>
 		/// Gets the assembly title
 		/// </summary>
-		public string Title
-		{
-			get
-			{
-				return GetAttribute<AssemblyTitleAttribute>(a => a.Title);
-			}
-		}
+		public string Title => GetAttribute<AssemblyTitleAttribute>(a => a.Title);
 
 		/// <summary>
 		/// Gets the assembly trademark information
 		/// </summary>
-		public string Trademark
-		{
-			get
-			{
-				return GetAttribute<AssemblyTrademarkAttribute>(a => a.Trademark);
-			}
-		}
+		public string Trademark => GetAttribute<AssemblyTrademarkAttribute>(a => a.Trademark);
 
 		/// <summary>
 		/// Creates a new AssemblyDetail object from the specified Assembly

--- a/src/AssemblyDetail.cs
+++ b/src/AssemblyDetail.cs
@@ -75,9 +75,13 @@ namespace Zyrenth.Zora
 			{
 				Version version = _asm.GetName().Version;
 				if (version is null)
+				{
 					return version.ToString();
+				}
 				else
+				{
 					return "0.0.0.0";
+				}
 			}
 		}
 
@@ -132,7 +136,10 @@ namespace Zyrenth.Zora
 		public AssemblyDetail(Assembly asm)
 		{
 			if (asm is null)
+			{
 				throw new ArgumentNullException(nameof(asm));
+			}
+
 			_asm = asm;
 		}
 

--- a/src/BatteryFileLoader.cs
+++ b/src/BatteryFileLoader.cs
@@ -75,17 +75,23 @@ namespace Zyrenth.Zora
 			tmp = Load(stream, region, Slot1Offset);
 			var gameData = new List<GameInfo>();
 			if (!( tmp is null ))
+			{
 				gameData.Add(tmp);
+			}
 
 			// Slot 2
 			tmp = Load(stream, region, Slot2Offset);
 			if (!( tmp is null ))
+			{
 				gameData.Add(tmp);
+			}
 
 			// Slot 3
 			tmp = Load(stream, region, Slot3Offset);
 			if (!( tmp is null ))
+			{
 				gameData.Add(tmp);
+			}
 
 			return gameData;
 		}
@@ -135,7 +141,9 @@ namespace Zyrenth.Zora
 
 			// The version is represented by the char values '1' or '2'
 			if (versionBytes[0] != 49 && versionBytes[0] != 50)
+			{
 				return null;
+			}
 
 			stream.Seek(76, SeekOrigin.Current);
 			stream.Read(gameIdBytes, 0, 2);
@@ -159,9 +167,13 @@ namespace Zyrenth.Zora
 
 			System.Text.Encoding enc = null;
 			if (region == GameRegion.US)
+			{
 				enc = new USEncoding();
+			}
 			else
+			{
 				enc = new JapaneseEncoding();
+			}
 
 			info.Game = versionBytes[0] == 49 ? Game.Seasons : Game.Ages;
 			info.GameID = BitConverter.ToInt16(gameIdBytes, 0);

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -68,7 +68,7 @@ namespace Zyrenth.Zora
 
 					method = method.MakeGenericMethod(type);
 
-					var args = new object[] { ReadValue<string>(dictionary, key), default(T) };
+					object[] args = new object[] { ReadValue<string>(dictionary, key), default(T) };
 					method.Invoke(null, args);
 
 					val = (T)args[1];

--- a/src/GameInfo.cs
+++ b/src/GameInfo.cs
@@ -80,7 +80,10 @@ namespace Zyrenth.Zora
 			set
 			{
 				if (( value < 0 ) || ( (int)value > byte.MaxValue ))
+				{
 					throw new ArgumentOutOfRangeException(nameof(value));
+				}
+
 				SetProperty(ref _agesSeasons, (byte)value, "Game");
 			}
 		}
@@ -130,9 +133,14 @@ namespace Zyrenth.Zora
 			set
 			{
 				if (string.IsNullOrWhiteSpace(value))
+				{
 					value = "\0\0\0\0\0";
+				}
 				else
+				{
 					value = value.TrimEnd().PadRight(5, '\0');
+				}
+
 				SetProperty(ref _hero, value, "Hero");
 			}
 		}
@@ -146,9 +154,14 @@ namespace Zyrenth.Zora
 			set
 			{
 				if (string.IsNullOrWhiteSpace(value))
+				{
 					value = "\0\0\0\0\0";
+				}
 				else
+				{
 					value = value.TrimEnd().PadRight(5, '\0');
+				}
+
 				SetProperty(ref _child, value, "Child");
 			}
 		}
@@ -162,7 +175,10 @@ namespace Zyrenth.Zora
 			set
 			{
 				if (( value < 0 ) || ( (long)value > byte.MaxValue ))
+				{
 					throw new ArgumentOutOfRangeException(nameof(value));
+				}
+
 				SetProperty(ref _animal, (byte)value, "Animal");
 			}
 		}
@@ -371,7 +387,9 @@ namespace Zyrenth.Zora
 		public override bool Equals(object obj)
 		{
 			if (GetType() != obj?.GetType())
+			{
 				return false;
+			}
 
 			var g = (GameInfo)obj;
 

--- a/src/GameInfo.cs
+++ b/src/GameInfo.cs
@@ -64,11 +64,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public GameRegion Region
 		{
-			get { return _region; }
-			set
-			{
-				SetProperty(ref _region, value, "Region");
-			}
+			get => _region;
+			set => SetProperty(ref _region, value, "Region");
 		}
 
 		/// <summary>
@@ -76,9 +73,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Game Game
 		{
-			get { return (Game)_agesSeasons; }
-			set
-			{
+			get => (Game)_agesSeasons;
+			set {
 				if (( value < 0 ) || ( (int)value > byte.MaxValue ))
 				{
 					throw new ArgumentOutOfRangeException(nameof(value));
@@ -93,11 +89,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public bool IsHeroQuest
 		{
-			get { return _isHeroQuest; }
-			set
-			{
-				SetProperty(ref _isHeroQuest, value, "IsHeroQuest");
-			}
+			get => _isHeroQuest;
+			set => SetProperty(ref _isHeroQuest, value, "IsHeroQuest");
 		}
 
 		/// <summary>
@@ -105,11 +98,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public bool IsLinkedGame
 		{
-			get { return _isLinkedGame; }
-			set
-			{
-				SetProperty(ref _isLinkedGame, value, "IsLinkedGame");
-			}
+			get => _isLinkedGame;
+			set => SetProperty(ref _isLinkedGame, value, "IsLinkedGame");
 		}
 
 		/// <summary>
@@ -117,11 +107,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public short GameID
 		{
-			get { return _gameId; }
-			set
-			{
-				SetProperty(ref _gameId, value, "GameID");
-			}
+			get => _gameId;
+			set => SetProperty(ref _gameId, value, "GameID");
 		}
 
 		/// <summary>
@@ -129,9 +116,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public string Hero
 		{
-			get { return _hero.Trim(' ', '\0'); }
-			set
-			{
+			get => _hero.Trim(' ', '\0');
+			set {
 				if (string.IsNullOrWhiteSpace(value))
 				{
 					value = "\0\0\0\0\0";
@@ -150,9 +136,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public string Child
 		{
-			get { return _child.Trim(' ', '\0'); }
-			set
-			{
+			get => _child.Trim(' ', '\0');
+			set {
 				if (string.IsNullOrWhiteSpace(value))
 				{
 					value = "\0\0\0\0\0";
@@ -171,9 +156,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Animal Animal
 		{
-			get { return (Animal)_animal; }
-			set
-			{
+			get => (Animal)_animal;
+			set {
 				if (( value < 0 ) || ( (long)value > byte.MaxValue ))
 				{
 					throw new ArgumentOutOfRangeException(nameof(value));
@@ -188,11 +172,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public byte Behavior
 		{
-			get { return (byte)_behavior; }
-			set
-			{
-				SetProperty(ref _behavior, value, "Behavior");
-			}
+			get => (byte)_behavior;
+			set => SetProperty(ref _behavior, value, "Behavior");
 		}
 
 		/// <summary>
@@ -200,11 +181,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public bool WasGivenFreeRing
 		{
-			get { return _wasGivenFreeRing; }
-			set
-			{
-				SetProperty(ref _wasGivenFreeRing, value, "WasGivenFreeRing");
-			}
+			get => _wasGivenFreeRing;
+			set => SetProperty(ref _wasGivenFreeRing, value, "WasGivenFreeRing");
 		}
 
 		/// <summary>
@@ -212,11 +190,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Rings Rings
 		{
-			get { return (Rings)_rings; }
-			set
-			{
-				SetProperty(ref _rings, (long)value, "Rings");
-			}
+			get => (Rings)_rings;
+			set => SetProperty(ref _rings, (long)value, "Rings");
 		}
 
 		#endregion // Properties

--- a/src/GameInfoJsonConverter.cs
+++ b/src/GameInfoJsonConverter.cs
@@ -46,7 +46,9 @@ namespace Zyrenth.Zora
 		public GameInfo Deserialize(IDictionary<string, object> dictionary)
 		{
 			if (dictionary is null)
+			{
 				throw new ArgumentNullException(nameof(dictionary));
+			}
 
 			var info = new GameInfo
 			{
@@ -77,7 +79,9 @@ namespace Zyrenth.Zora
 		public IDictionary<string, object> Serialize(GameInfo info)
 		{
 			if (info is null)
+			{
 				throw new ArgumentNullException(nameof(info));
+			}
 
 			var dict = new Dictionary<string, object>
 			{

--- a/src/GameSecret.cs
+++ b/src/GameSecret.cs
@@ -112,9 +112,14 @@ namespace Zyrenth.Zora
 			set
 			{
 				if (string.IsNullOrWhiteSpace(value))
+				{
 					value = "\0\0\0\0\0";
+				}
 				else
+				{
 					value = value.TrimEnd().PadRight(5, '\0');
+				}
+
 				SetProperty(ref _hero, value, "Hero");
 			}
 		}
@@ -128,9 +133,14 @@ namespace Zyrenth.Zora
 			set
 			{
 				if (string.IsNullOrWhiteSpace(value))
+				{
 					value = "\0\0\0\0\0";
+				}
 				else
+				{
 					value = value.TrimEnd().PadRight(5, '\0');
+				}
+
 				SetProperty(ref _child, value, "Child");
 			}
 		}
@@ -260,7 +270,9 @@ namespace Zyrenth.Zora
 		public override void Load(byte[] secret, GameRegion region)
 		{
 			if (secret is null || secret.Length != Length)
+			{
 				throw new SecretException("Secret must contatin exactly 20 bytes");
+			}
 
 			Region = region;
 
@@ -272,12 +284,16 @@ namespace Zyrenth.Zora
 			var checksum = CalculateChecksum(clonedBytes);
 
 			if (( decodedBytes[19] & 7 ) != ( checksum & 7 ))
+			{
 				throw new InvalidChecksumException("Checksum does not match expected value");
+			}
 
 			GameID = Convert.ToInt16(decodedSecret.ReversedSubstring(5, 15), 2);
 
 			if (decodedSecret[3] != '0' || decodedSecret[4] != '0')
+			{
 				throw new ArgumentException("The specified data is not a game code", nameof(secret));
+			}
 
 			TargetGame = decodedSecret[21] == '1' ? Game.Seasons : Game.Ages;
 			IsHeroQuest = decodedSecret[20] == '1';
@@ -285,9 +301,13 @@ namespace Zyrenth.Zora
 
 			Encoding encoding;
 			if (region == GameRegion.US)
+			{
 				encoding = new USEncoding();
+			}
 			else
+			{
 				encoding = new JapaneseEncoding();
+			}
 
 			Hero = encoding.GetString(new byte[] {
 				Convert.ToByte(decodedSecret.ReversedSubstring(22, 8), 2),
@@ -335,9 +355,13 @@ namespace Zyrenth.Zora
 		{
 			Encoding encoding;
 			if (Region == GameRegion.US)
+			{
 				encoding = new USEncoding();
+			}
 			else
+			{
 				encoding = new JapaneseEncoding();
+			}
 
 			byte[] heroBytes = encoding.GetBytes(_hero);
 			byte[] childBytes = encoding.GetBytes(_child);
@@ -418,7 +442,9 @@ namespace Zyrenth.Zora
 		public bool IsValidForPAL()
 		{
 			if (_animal != 0x0b && _animal != 0x0c && _animal != 0x0d)
+			{
 				return false;
+			}
 
 			Encoding encoding = new USEncoding();
 			byte[] heroBytes = encoding.GetBytes(_hero);
@@ -427,9 +453,14 @@ namespace Zyrenth.Zora
 			for (int i = 0; i < 5; i++)
 			{
 				if (!validPALCharacters.Contains(heroBytes[i]))
+				{
 					return false;
+				}
+
 				if (!validPALCharacters.Contains(childBytes[i]))
+				{
 					return false;
+				}
 			}
 
 			return true;
@@ -445,8 +476,9 @@ namespace Zyrenth.Zora
 		public override bool Equals(object obj)
 		{
 			if (GetType() != obj?.GetType())
+			{
 				return false;
-
+			}
 
 			var g = (GameSecret)obj;
 

--- a/src/GameSecret.cs
+++ b/src/GameSecret.cs
@@ -62,10 +62,7 @@ namespace Zyrenth.Zora
 		/// <summary>
 		/// Gets the required length of the secret
 		/// </summary>
-		public override int Length
-		{
-			get { return 20; }
-		}
+		public override int Length => 20;
 
 		/// <summary>
 		/// Gets or sets the Game used for this user data

--- a/src/GameSecret.cs
+++ b/src/GameSecret.cs
@@ -72,11 +72,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Game TargetGame
 		{
-			get { return _targetGame; }
-			set
-			{
-				SetProperty(ref _targetGame, value, "Game");
-			}
+			get => _targetGame;
+			set => SetProperty(ref _targetGame, value, "Game");
 		}
 
 		/// <summary>
@@ -84,11 +81,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public bool IsHeroQuest
 		{
-			get { return _isHeroQuest; }
-			set
-			{
-				SetProperty(ref _isHeroQuest, value, "IsHeroQuest");
-			}
+			get => _isHeroQuest;
+			set => SetProperty(ref _isHeroQuest, value, "IsHeroQuest");
 		}
 
 		/// <summary>
@@ -96,11 +90,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public bool IsLinkedGame
 		{
-			get { return _isLinkedGame; }
-			set
-			{
-				SetProperty(ref _isLinkedGame, value, "IsLinkedGame");
-			}
+			get => _isLinkedGame;
+			set => SetProperty(ref _isLinkedGame, value, "IsLinkedGame");
 		}
 
 		/// <summary>
@@ -108,9 +99,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public string Hero
 		{
-			get { return _hero.Trim(' ', '\0'); }
-			set
-			{
+			get => _hero.Trim(' ', '\0');
+			set {
 				if (string.IsNullOrWhiteSpace(value))
 				{
 					value = "\0\0\0\0\0";
@@ -129,9 +119,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public string Child
 		{
-			get { return _child.Trim(' ', '\0'); }
-			set
-			{
+			get => _child.Trim(' ', '\0');
+			set {
 				if (string.IsNullOrWhiteSpace(value))
 				{
 					value = "\0\0\0\0\0";
@@ -150,11 +139,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Animal Animal
 		{
-			get { return (Animal)_animal; }
-			set
-			{
-				SetProperty(ref _animal, (byte)value, "Animal");
-			}
+			get => (Animal)_animal;
+			set => SetProperty(ref _animal, (byte)value, "Animal");
 		}
 
 		/// <summary>
@@ -162,11 +148,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public byte Behavior
 		{
-			get { return (byte)_behavior; }
-			set
-			{
-				SetProperty(ref _behavior, value, "Behavior");
-			}
+			get => (byte)_behavior;
+			set => SetProperty(ref _behavior, value, "Behavior");
 		}
 
 		/// <summary>
@@ -174,9 +157,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public bool WasGivenFreeRing
 		{
-			get { return _wasGivenFreeRing; }
-			set
-			{
+			get => _wasGivenFreeRing;
+			set {
 				_wasGivenFreeRing = value;
 				SetProperty(ref _wasGivenFreeRing, value, "WasGivenFreeRing");
 			}

--- a/src/GameSecret.cs
+++ b/src/GameSecret.cs
@@ -281,7 +281,7 @@ namespace Zyrenth.Zora
 
 			byte[] clonedBytes = (byte[])decodedBytes.Clone();
 			clonedBytes[19] = 0;
-			var checksum = CalculateChecksum(clonedBytes);
+			byte checksum = CalculateChecksum(clonedBytes);
 
 			if (( decodedBytes[19] & 7 ) != ( checksum & 7 ))
 			{

--- a/src/JapaneseEncoding.cs
+++ b/src/JapaneseEncoding.cs
@@ -89,7 +89,9 @@ namespace Zyrenth.Zora
 				}
 
 				if (c == 0)
+				{
 					b = 0;
+				}
 				else
 				{
 					for (int j = 0; j < characters.Length; j++)
@@ -135,9 +137,13 @@ namespace Zyrenth.Zora
 			{
 				int b = bytes[i] - 0x10;
 				if (b < 0 || b >= characters.Length)
+				{
 					chars[i] = '\0';
+				}
 				else
+				{
 					chars[i] = characters[b];
+				}
 			}
 
 			return byteCount;

--- a/src/MemorySecret.cs
+++ b/src/MemorySecret.cs
@@ -162,9 +162,14 @@ namespace Zyrenth.Zora
 		public override void Load(byte[] secret, GameRegion region)
 		{
 			if (secret is null)
+			{
 				throw new ArgumentNullException(nameof(secret));
+			}
+
 			if (secret.Length != Length)
+			{
 				throw new SecretException("Secret must contatin exactly 5 bytes");
+			}
 
 			Region = region;
 
@@ -176,10 +181,14 @@ namespace Zyrenth.Zora
 			var checksum = CalculateChecksum(clonedBytes);
 
 			if (( decodedBytes[4] & 7 ) != ( checksum & 7 ))
+			{
 				throw new InvalidChecksumException("Checksum does not match expected value");
+			}
 
 			if (decodedSecret[3] != '1' || decodedSecret[4] != '1')
+			{
 				throw new ArgumentException("The specified data is not a memory code", nameof(secret));
+			}
 
 			GameID = Convert.ToInt16(decodedSecret.ReversedSubstring(5, 15), 2);
 			Memory = (Memory)Convert.ToByte(decodedSecret.ReversedSubstring(20, 4), 2);
@@ -210,7 +219,9 @@ namespace Zyrenth.Zora
 			}
 
 			if (!found)
+			{
 				throw new UnknownMemoryException("Cound not determine the type of memory secret");
+			}
 		}
 
 		/// <summary>
@@ -233,9 +244,13 @@ namespace Zyrenth.Zora
 		{
 			int cipher = 0;
 			if (TargetGame == Game.Ages)
+			{
 				cipher = _isReturnSecret ? 3 : 0;
+			}
 			else
+			{
 				cipher = _isReturnSecret ? 1 : 2;
+			}
 
 			cipher |= ( ( (byte)_memory & 1 ) << 2 );
 			cipher = ( ( GameID >> 8 ) + ( GameID & 255 ) + cipher ) & 7;
@@ -251,9 +266,14 @@ namespace Zyrenth.Zora
 			int mask = 0;
 
 			if (TargetGame == Game.Ages)
+			{
 				mask = _isReturnSecret ? 3 : 0;
+			}
 			else
+			{
 				mask = _isReturnSecret ? 2 : 1;
+			}
+
 			byte[] unencodedBytes = BinaryStringToByteArray(unencodedSecret);
 			unencodedBytes[4] = (byte)( CalculateChecksum(unencodedBytes) | ( mask << 4 ) );
 			byte[] secret = EncodeBytes(unencodedBytes);
@@ -271,7 +291,9 @@ namespace Zyrenth.Zora
 		public override bool Equals(object obj)
 		{
 			if (GetType() != obj?.GetType())
+			{
 				return false;
+			}
 
 			var g = (MemorySecret)obj;
 

--- a/src/MemorySecret.cs
+++ b/src/MemorySecret.cs
@@ -47,11 +47,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Memory Memory
 		{
-			get { return (Memory)_memory; }
-			set
-			{
-				SetProperty(ref _memory, (byte)value, "Memory");
-			}
+			get => (Memory)_memory;
+			set => SetProperty(ref _memory, (byte)value, "Memory");
 		}
 
 		/// <summary>
@@ -59,11 +56,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Game TargetGame
 		{
-			get { return (Game)_targetGame; }
-			set
-			{
-				SetProperty(ref _targetGame, (byte)value, "Game");
-			}
+			get => (Game)_targetGame;
+			set => SetProperty(ref _targetGame, (byte)value, "Game");
 		}
 
 		/// <summary>
@@ -74,11 +68,8 @@ namespace Zyrenth.Zora
 		/// </value>
 		public bool IsReturnSecret
 		{
-			get { return _isReturnSecret; }
-			set
-			{
-				SetProperty(ref _isReturnSecret, value, "IsReturnSecret");
-			}
+			get => _isReturnSecret;
+			set => SetProperty(ref _isReturnSecret, value, "IsReturnSecret");
 		}
 
 		/// <summary>

--- a/src/MemorySecret.cs
+++ b/src/MemorySecret.cs
@@ -37,10 +37,7 @@ namespace Zyrenth.Zora
 		/// <summary>
 		/// Gets the required length of the secret
 		/// </summary>
-		public override int Length
-		{
-			get { return 5; }
-		}
+		public override int Length => 5;
 
 		/// <summary>
 		/// Gets or sets the memory to use for this secret

--- a/src/MemorySecret.cs
+++ b/src/MemorySecret.cs
@@ -178,7 +178,7 @@ namespace Zyrenth.Zora
 
 			byte[] clonedBytes = (byte[])decodedBytes.Clone();
 			clonedBytes[4] = 0;
-			var checksum = CalculateChecksum(clonedBytes);
+			byte checksum = CalculateChecksum(clonedBytes);
 
 			if (( decodedBytes[4] & 7 ) != ( checksum & 7 ))
 			{
@@ -197,7 +197,7 @@ namespace Zyrenth.Zora
 			// we compare it against all four possible values. It's ugly, but it works.
 			string desiredString = SecretParser.CreateString(secret, Region);
 
-			var memories = new[]
+			MemorySecret[] memories = new[]
 			{
 				new MemorySecret(Game.Ages, region, GameID, Memory, true),
 				new MemorySecret(Game.Ages, region, GameID, Memory, false),
@@ -207,7 +207,7 @@ namespace Zyrenth.Zora
 
 			bool found = false;
 
-			foreach (var memSecret in memories)
+			foreach (MemorySecret memSecret in memories)
 			{
 				if (desiredString == memSecret.ToString())
 				{

--- a/src/RingSecret.cs
+++ b/src/RingSecret.cs
@@ -45,11 +45,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public Rings Rings
 		{
-			get { return (Rings)_rings; }
-			set
-			{
-				SetProperty(ref _rings, (long)value, "Rings");
-			}
+			get => (Rings)_rings;
+			set => SetProperty(ref _rings, (long)value, "Rings");
 		}
 
 		/// <summary>

--- a/src/RingSecret.cs
+++ b/src/RingSecret.cs
@@ -126,7 +126,9 @@ namespace Zyrenth.Zora
 		public override void Load(byte[] secret, GameRegion region)
 		{
 			if (secret is null || secret.Length != Length)
+			{
 				throw new SecretException("Secret must contatin exactly 15 bytes");
+			}
 
 			Region = region;
 
@@ -138,10 +140,14 @@ namespace Zyrenth.Zora
 			var checksum = CalculateChecksum(clonedBytes);
 
 			if (( decodedBytes[14] & 7 ) != ( checksum & 7 ))
+			{
 				throw new InvalidChecksumException("Checksum does not match expected value");
+			}
 
 			if (decodedSecret[3] != '0' || decodedSecret[4] != '1')
+			{
 				throw new ArgumentException("The specified data is not a ring code", nameof(secret));
+			}
 
 			GameID = Convert.ToInt16(decodedSecret.ReversedSubstring(5, 15), 2);
 
@@ -231,10 +237,14 @@ namespace Zyrenth.Zora
 		public void UpdateGameInfo(GameInfo info, bool appendRings)
 		{
 			if (info.Region != Region)
+			{
 				throw new SecretException("The regions of the secret and game info do not match.");
+			}
 
 			if (info.GameID != GameID)
+			{
 				throw new SecretException("The Game IDs of the secret and game info do not match. (Secret's Game ID is " + GameID + ".)");
+			}
 
 			info.Rings = Rings | ( appendRings ? info.Rings : Rings.None );
 		}
@@ -249,7 +259,9 @@ namespace Zyrenth.Zora
 		public override bool Equals(object obj)
 		{
 			if (GetType() != obj?.GetType())
+			{
 				return false;
+			}
 
 			var g = (RingSecret)obj;
 

--- a/src/RingSecret.cs
+++ b/src/RingSecret.cs
@@ -35,10 +35,7 @@ namespace Zyrenth.Zora
 		/// <summary>
 		/// Gets the required length of the secret
 		/// </summary>
-		public override int Length
-		{
-			get { return 15; }
-		}
+		public override int Length => 15;
 
 		/// <summary>
 		/// Gets or sets the user's ring collection

--- a/src/RingSecret.cs
+++ b/src/RingSecret.cs
@@ -137,7 +137,7 @@ namespace Zyrenth.Zora
 
 			byte[] clonedBytes = (byte[])decodedBytes.Clone();
 			clonedBytes[14] = 0;
-			var checksum = CalculateChecksum(clonedBytes);
+			byte checksum = CalculateChecksum(clonedBytes);
 
 			if (( decodedBytes[14] & 7 ) != ( checksum & 7 ))
 			{

--- a/src/Secret.cs
+++ b/src/Secret.cs
@@ -74,11 +74,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public short GameID
 		{
-			get { return _gameId; }
-			set
-			{
-				SetProperty(ref _gameId, value, "GameID");
-			}
+			get => _gameId;
+			set => SetProperty(ref _gameId, value, "GameID");
 		}
 
 		/// <summary>
@@ -86,11 +83,8 @@ namespace Zyrenth.Zora
 		/// </summary>
 		public GameRegion Region
 		{
-			get { return _region; }
-			set
-			{
-				SetProperty(ref _region, value, "Region");
-			}
+			get => _region;
+			set => SetProperty(ref _region, value, "Region");
 		}
 
 		/// <summary>

--- a/src/Secret.cs
+++ b/src/Secret.cs
@@ -293,7 +293,9 @@ namespace Zyrenth.Zora
 		public override bool Equals(object obj)
 		{
 			if (GetType() != obj?.GetType())
+			{
 				return false;
+			}
 
 			var g = (Secret)obj;
 

--- a/src/SecretParser.cs
+++ b/src/SecretParser.cs
@@ -120,7 +120,7 @@ namespace Zyrenth.Zora
 		/// </example>
 		public static byte[] ParseSecret(string secret, GameRegion region)
 		{
-			foreach (var kvp in symbolRegexes[(int)region].OrderByDescending(x => x.Key.Length))
+			foreach (KeyValuePair<string, string> kvp in symbolRegexes[(int)region].OrderByDescending(x => x.Key.Length))
 			{
 				secret = Regex.Replace(secret, kvp.Key, kvp.Value, RegexOptions.IgnoreCase);
 			}

--- a/src/SecretParser.cs
+++ b/src/SecretParser.cs
@@ -131,7 +131,9 @@ namespace Zyrenth.Zora
 			{
 				symbol = Array.IndexOf(symbols[(int)region], secret[i]);
 				if (symbol < 0 || symbol > 63)
+				{
 					throw new SecretException("Secret contains invalid symbols");
+				}
 
 				data[i] = (byte)symbol;
 			}
@@ -168,11 +170,15 @@ namespace Zyrenth.Zora
 			for (int i = 0; i < data.Length; ++i)
 			{
 				if (data[i] < 0 || data[i] > 63)
+				{
 					throw new SecretException("Secret contains invalid values");
+				}
 
 				sBuilder.Append(symbols[(int)region][data[i]]);
 				if (i % 5 == 4)
+				{
 					sBuilder.Append(" ");
+				}
 			}
 			return sBuilder.ToString().Trim();
 		}

--- a/src/USEncoding.cs
+++ b/src/USEncoding.cs
@@ -80,7 +80,9 @@ namespace Zyrenth.Zora
 				char c = chars[i];
 
 				if (c == 0)
+				{
 					b = 0;
+				}
 				else
 				{
 					for (int j = 0; j < characters.Length; j++)
@@ -126,9 +128,13 @@ namespace Zyrenth.Zora
 			{
 				int b = bytes[i] - 0x10;
 				if (b < 0 || b >= characters.Length)
+				{
 					chars[i] = '\0';
+				}
 				else
+				{
 					chars[i] = characters[b];
+				}
 			}
 
 			return byteCount;

--- a/test/SecretParserTest.cs
+++ b/test/SecretParserTest.cs
@@ -29,7 +29,7 @@ namespace Zyrenth.Zora.Tests
 			string s3 = "H~2:@ left 2 diamond yq GB3 circle ) 6 heart ? up 4";
 			string s4 = "H~2 :@LEFT2{dIAmoNd}yq G B3cirCle )6 heaRT}?    UP   4";
 
-			var allSecrets = new[] {
+			byte[][] allSecrets = new[] {
 				SecretParser.ParseSecret(s1, GameRegion.US),
 				SecretParser.ParseSecret(s2, GameRegion.US),
 				SecretParser.ParseSecret(s3, GameRegion.US),


### PR DESCRIPTION
This covers the following coding style messages, each of which occurred as a distinct commit, to simplify review.  The .editorconfig file was also manually modified in support of these changes.
* IDE0025 - Use expression body for properties (single-line only)
* IDE0027 - Use expression body for accessors (single-line only)
* IDE0008 - Use explicit type instead of 'var'
* IDE0011 - Add braces to 'if' and 'else' statements
