### PR TITLE
Blazor related changes

### DIFF
--- a/src/GameInfo.cs
+++ b/src/GameInfo.cs
@@ -20,19 +20,24 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
+
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+using System.ComponentModel;
+#endif
 
 namespace Zyrenth.Zora
 {
 	/// <summary>
 	/// Represents the user data for an individual game
 	/// </summary>
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
 	[Serializable]
-	public class GameInfo : INotifyPropertyChanged
+#endif
+	public class GameInfo
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+		: INotifyPropertyChanged
+#endif
 	{
 
 		#region Fields
@@ -51,11 +56,15 @@ namespace Zyrenth.Zora
 
 		#endregion // Fields
 
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+
 		/// <summary>
 		/// Occurs when a property has changed
 		/// </summary>
 		[field: NonSerialized]
 		public event PropertyChangedEventHandler PropertyChanged;
+
+#endif
 
 		#region Properties
 
@@ -222,7 +231,9 @@ namespace Zyrenth.Zora
 			if (!EqualityComparer<T>.Default.Equals(field, value))
 			{
 				field = value;
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+#endif
 			}
 		}
 

--- a/src/GameInfo.cs
+++ b/src/GameInfo.cs
@@ -22,7 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 using System.ComponentModel;
 #endif
 
@@ -31,11 +31,11 @@ namespace Zyrenth.Zora
 	/// <summary>
 	/// Represents the user data for an individual game
 	/// </summary>
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 	[Serializable]
 #endif
 	public class GameInfo
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 		: INotifyPropertyChanged
 #endif
 	{
@@ -56,7 +56,7 @@ namespace Zyrenth.Zora
 
 		#endregion // Fields
 
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 
 		/// <summary>
 		/// Occurs when a property has changed
@@ -231,7 +231,7 @@ namespace Zyrenth.Zora
 			if (!EqualityComparer<T>.Default.Equals(field, value))
 			{
 				field = value;
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 #endif
 			}

--- a/src/Secret.cs
+++ b/src/Secret.cs
@@ -22,7 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 using System.ComponentModel;
 #endif
 
@@ -32,7 +32,7 @@ namespace Zyrenth.Zora
 	/// Represents a secret used in the Zelda Oracle series games.
 	/// </summary>
 	public abstract class Secret
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 		: INotifyPropertyChanged
 #endif
 	{
@@ -62,7 +62,7 @@ namespace Zyrenth.Zora
 		private short _gameId = 0;
 		private GameRegion _region = GameRegion.US;
 
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 
 		/// <summary>
 		/// Occurs when a property has changed
@@ -281,7 +281,7 @@ namespace Zyrenth.Zora
 			if (!EqualityComparer<T>.Default.Equals(field, value))
 			{
 				field = value;
-#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+#if !BLAZOR
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 #endif
 			}

--- a/src/Secret.cs
+++ b/src/Secret.cs
@@ -20,16 +20,21 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Text;
+
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+using System.ComponentModel;
+#endif
 
 namespace Zyrenth.Zora
 {
 	/// <summary>
 	/// Represents a secret used in the Zelda Oracle series games.
 	/// </summary>
-	public abstract class Secret : INotifyPropertyChanged
+	public abstract class Secret
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+		: INotifyPropertyChanged
+#endif
 	{
 		private static readonly byte[][] ciphers =
 		{
@@ -57,12 +62,15 @@ namespace Zyrenth.Zora
 		private short _gameId = 0;
 		private GameRegion _region = GameRegion.US;
 
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
+
 		/// <summary>
 		/// Occurs when a property has changed
 		/// </summary>
 		[field: NonSerialized]
 		public event PropertyChangedEventHandler PropertyChanged;
 
+#endif
 
 		/// <summary>
 		/// Gets the required length of the secret
@@ -273,7 +281,9 @@ namespace Zyrenth.Zora
 			if (!EqualityComparer<T>.Default.Equals(field, value))
 			{
 				field = value;
+#if !(BLAZOR_NO_NOTIFY_PROPERTY_CHANGED)
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+#endif
 			}
 		}
 

--- a/src/ZoraSharp.csproj
+++ b/src/ZoraSharp.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration>BlazorDebug</Configuration>
-    <Platform>AnyCPU</Platform>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{E40D4A82-F5F3-4712-A8E2-AD3C77B1E5A8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Zyrenth.Zora</RootNamespace>
@@ -27,17 +27,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
     <DocumentationFile>bin\Release\ZoraSharp.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'BlazorDebug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
-    <DefineConstants>DEBUG;BLAZOR_NO_NOTIFY_PROPERTY_CHANGED;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>False</ConsolePause>
-    <DocumentationFile>bin\BlazorDebug\ZoraSharp.xml</DocumentationFile>
-    <OutputPath>bin\BlazorDebug\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -64,6 +53,8 @@
     <Compile Include="InvalidChecksumException.cs" />
     <Compile Include="UnknownMemoryException.cs" />
   </ItemGroup>
+  <!-- Allow projects to override or extend project configuration -->
+  <Import Project="$(SolutionDir)Extra.targets" Condition="exists('$(SolutionDir)Extra.targets')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <MonoDevelop>

--- a/src/ZoraSharp.csproj
+++ b/src/ZoraSharp.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Configuration>BlazorDebug</Configuration>
+    <Platform>AnyCPU</Platform>
     <ProjectGuid>{E40D4A82-F5F3-4712-A8E2-AD3C77B1E5A8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Zyrenth.Zora</RootNamespace>
@@ -27,6 +27,17 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
     <DocumentationFile>bin\Release\ZoraSharp.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'BlazorDebug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <DefineConstants>DEBUG;BLAZOR_NO_NOTIFY_PROPERTY_CHANGED;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>False</ConsolePause>
+    <DocumentationFile>bin\BlazorDebug\ZoraSharp.xml</DocumentationFile>
+    <OutputPath>bin\BlazorDebug\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
I'll admit I have no idea what I have to do to the `csproj` to accept solution wide defines, so I did this.  
You can check out my [ZoraGen Blazor](https://github.com/friendlyanon/zoragen-blazor) project to maybe get a better idea what I tried to achieve here.

The reason why the `BLAZOR_NO_NOTIFY_PROPERTY_CHANGED` define needed to be introduced is that `System.ComponentModel.INotifyPropertyChanged` does not work with Blazor.

You most definitely should make changes to this PR if you know how to achieve perfectly what I tried to do here.